### PR TITLE
Attempt to ensure that watch is always sequential

### DIFF
--- a/pkg/drivers/mysql/mysql.go
+++ b/pkg/drivers/mysql/mysql.go
@@ -29,8 +29,8 @@ var (
 				create_revision INTEGER,
  				prev_revision INTEGER,
 				lease INTEGER,
- 				value BLOB,
- 				old_value BLOB,
+				value MEDIUMBLOB,
+				old_value MEDIUMBLOB,
 				PRIMARY KEY (id)
 			);`,
 	}

--- a/pkg/logstructured/logstructured.go
+++ b/pkg/logstructured/logstructured.go
@@ -2,6 +2,7 @@ package logstructured
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	"github.com/rancher/kine/pkg/server"
@@ -228,22 +229,60 @@ func (l *LogStructured) Update(ctx context.Context, key string, value []byte, re
 	return rev, updateEvent.KV, true, err
 }
 
-func (l *LogStructured) ttl(ctx context.Context) {
-	// very naive TTL support
-	for events := range l.log.Watch(ctx, "/") {
-		for _, event := range events {
-			if event.KV.Lease <= 0 {
-				continue
+func (l *LogStructured) ttlEvents(ctx context.Context) chan *server.Event {
+	result := make(chan *server.Event)
+	wg := sync.WaitGroup{}
+	wg.Add(2)
+
+	go func() {
+		wg.Wait()
+		close(result)
+	}()
+
+	go func() {
+		defer wg.Done()
+		rev, events, err := l.log.List(ctx, "/", "", 1000, 0, false)
+		for len(events) > 0 {
+			if err != nil {
+				logrus.Errorf("failed to read old events for ttl")
+				return
 			}
-			go func(event *server.Event) {
-				select {
-				case <-ctx.Done():
-					return
-				case <-time.After(time.Duration(event.KV.Lease) * time.Second):
+
+			for _, event := range events {
+				if event.KV.Lease > 0 {
+					result <- event
 				}
-				l.Delete(ctx, event.KV.Key, event.KV.ModRevision)
-			}(event)
+			}
+
+			_, events, err = l.log.List(ctx, "/", events[len(events)-1].KV.Key, 1000, rev, false)
 		}
+	}()
+
+	go func() {
+		defer wg.Done()
+		for events := range l.log.Watch(ctx, "/") {
+			for _, event := range events {
+				if event.KV.Lease > 0 {
+					result <- event
+				}
+			}
+		}
+	}()
+
+	return result
+}
+
+func (l *LogStructured) ttl(ctx context.Context) {
+	// vary naive TTL support
+	for event := range l.ttlEvents(ctx) {
+		go func(event *server.Event) {
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(time.Duration(event.KV.Lease) * time.Second):
+			}
+			l.Delete(ctx, event.KV.Key, event.KV.ModRevision)
+		}(event)
 	}
 }
 

--- a/pkg/logstructured/logstructured.go
+++ b/pkg/logstructured/logstructured.go
@@ -298,7 +298,7 @@ func (l *LogStructured) Watch(ctx context.Context, prefix string, revision int64
 		revision -= 1
 	}
 
-	result := make(chan []*server.Event)
+	result := make(chan []*server.Event, 100)
 
 	rev, kvs, err := l.log.After(ctx, prefix, revision)
 	if err != nil {

--- a/pkg/logstructured/logstructured.go
+++ b/pkg/logstructured/logstructured.go
@@ -106,7 +106,13 @@ func (l *LogStructured) Create(ctx context.Context, key string, value []byte, le
 		createEvent.PrevKV = prevEvent.KV
 	}
 
-	return l.log.Append(ctx, createEvent)
+	revRet, errRet = l.log.Append(ctx, createEvent)
+	if errRet != nil {
+		if _, prevEvent, err := l.get(ctx, key, 0, true); err == nil && prevEvent != nil && !prevEvent.Delete {
+			return 0, server.ErrKeyExists
+		}
+	}
+	return
 }
 
 func (l *LogStructured) Delete(ctx context.Context, key string, revision int64) (revRet int64, kvRet *server.KeyValue, deletedRet bool, errRet error) {

--- a/pkg/logstructured/sqllog/sql.go
+++ b/pkg/logstructured/sqllog/sql.go
@@ -231,7 +231,7 @@ func RowsToEvents(rows *sql.Rows) (int64, int64, []*server.Event, error) {
 }
 
 func (s *SQLLog) Watch(ctx context.Context, prefix string) <-chan []*server.Event {
-	res := make(chan []*server.Event)
+	res := make(chan []*server.Event, 100)
 	values, err := s.broadcaster.Subscribe(ctx, s.startWatch)
 	if err != nil {
 		return nil

--- a/pkg/server/watch.go
+++ b/pkg/server/watch.go
@@ -87,7 +87,7 @@ func (w *watcher) Start(r *etcdserverpb.WatchCreateRequest) {
 				Events:  toEvents(events...),
 			}); err != nil {
 				w.Cancel(id)
-				return
+				continue
 			}
 		}
 		logrus.Debugf("WATCH CLOSE id=%d, key=%s", id, key)


### PR DESCRIPTION
This is currently untested, but the idea is to ensure that watch events are always sequential to avoid missing an ID due to an out of order insert.  In such a situation that we see a gap in the log we give up to 1 second to find the missing record.  If it is not discovered in 1 second we move on with the log.